### PR TITLE
Unlink temp zip file to prevent appending to it when downloading a folder

### DIFF
--- a/src/Api/LocalApi.php
+++ b/src/Api/LocalApi.php
@@ -660,6 +660,11 @@ class LocalApi implements ApiInterface
         $event = new ApiEvent\AfterItemDownloadEvent($model->getData());
         dispatcher()->dispatch($event::NAME, $event);
 
+	    // Unlink the zip file to prevent appending to it
+	    if (isset($destinationPath)) {
+		    unlink($destinationPath);
+	    }
+
         Log::info('downloaded "' . $targetPath . '"');
         exit;
     }


### PR DESCRIPTION
Steps to repeat problem:
- Create a folder
- Add some files to it
- Download the folder
- Delete some files but not all
- Download folder again
Problem: same content as first download, zip file has all files from "history".

Solution:
The zip file that gets created in the system temp directory has the same name as the folder that is downloaded. The content of the folder seems to be getting appended to it.
To prevent this, we can simply unlink the zip file when the download event is done.