### PR TITLE
Set headers on error before content

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -400,12 +400,13 @@ class Application
             'meta' => $meta,
         ];
 
+        header('Content-Type: application/json');
+        header('HTTP/1.1 500 Internal Server Error');
+        
         echo json_encode([
             'errors' => [$error_object],
         ]);
 
-        header('Content-Type: application/json');
-        header('HTTP/1.1 500 Internal Server Error');
         exit;
     }
 


### PR DESCRIPTION
On error, headers were set after the content was outputted. This causes PHP warnings about headers already sent. This fixes this problem by first setting headers.